### PR TITLE
chore: bump plugins to 2.27.2 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
 
 # The upstream Docker image build process is so involved that, instead of using their built-in plugin mechanism while building the "original" image [0], we rather copy the instructions here. Other than us doing this *after* the original image has been built, we strive to follow the upstream design as closely as possible.
 # [0] https://github.com/geosolutions-it/docker-geoserver/blob/fb6a5197b19c60cf9a4b83b440281e2110a021a0/Dockerfile#L46-L50
-ARG PLUG_IN_URLS='https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-inspire-plugin.zip'
+ARG PLUG_IN_URLS='https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.2/extensions/geoserver-2.27.2-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.2/extensions/geoserver-2.27.2-inspire-plugin.zip'
 RUN /usr/local/bin/geoserver-plugin-download.sh "${CATALINA_BASE}/webapps/geoserver/WEB-INF/lib" ${PLUG_IN_URLS}


### PR DESCRIPTION
This PR bumps the plugins versions to 2.27.2 to be in line with the geoserver version.